### PR TITLE
Add Prompt Generator component and fix markdown copy issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "react-markdown": "^10.1.0",
         "recharts": "^3.1.0",
         "rehype-highlight": "^7.0.2",
+        "remove-markdown": "^0.6.2",
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
         "zod": "^4.0.14"
@@ -9618,6 +9619,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/remove-markdown": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.6.2.tgz",
+      "integrity": "sha512-EijDXJZbzpGbQBd852ViUzcqgpMujthM+SAEHiWCMcZonRbZ+xViWKLJA/vrwbDwYdxrs1aFDjpBhcGrZoJRGA==",
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-markdown": "^10.1.0",
     "recharts": "^3.1.0",
     "rehype-highlight": "^7.0.2",
+    "remove-markdown": "^0.6.2",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.14"

--- a/src/app/api/generate-prompt/route.ts
+++ b/src/app/api/generate-prompt/route.ts
@@ -12,28 +12,30 @@ export async function POST(req: Request) {
     }
 
     const instruction = `
-You are **Promptify**, an elite Prompt Engineer AI. Your sole mission is to craft exceptional, tailored prompts that extract the **best possible output** from any AI model — such as GPT-4, Gemini, Claude, Mistral, or others.
+You are **Promptify**, an elite Prompt Engineering AI specialized in crafting high-quality prompts for AI models like GPT-4, Claude, Gemini, Mistral, and others.
 
-Style Preference: **${style.toUpperCase()}**
+**Style Preference:** ${style.toUpperCase()}
 
-Your Responsibilities:
-- Understand the user's intent with precision.
-- Generate clear, context-rich, and role-based prompts.
-- Always optimize for creativity, structure, and clarity.
-- Keep your entire response under **500 words**.
+**Your Role:**
+- Analyze the user's objective with accuracy and depth.
+- Generate a **single, optimized prompt only** — no explanations or auxiliary text.
+- Ensure the prompt is clear, specific, and contextually complete.
+- Keep the entire response strictly within **500 words**.
 
-Output Format (in Markdown):
-- **Goal:** Briefly explain what this prompt is trying to achieve.
-- **Prompt:** The exact prompt to use (well-structured and detailed).
-- **Tips:** Optional advice to tweak or extend the prompt.
+**Output Format (in Markdown):**
+- **Goal:** A brief, precise summary of the user's intent.
+- **Prompt:** The fully structured prompt — direct, detailed, and ready to use.
+- **Tips:** (Optional) Short suggestions for extending or customizing the prompt.
 
-Guidelines:
-- Never give vague or generic prompts.
-- Be concise yet powerful — no fluff.
-- When asked for multiple prompts, list them clearly and uniquely (use bullets or numbers).
-- Always think like a top-tier prompt engineer, not a chatbot.
+**Guidelines:**
+- Do **not** write in a conversational or assistant-like tone.
+- Do **not** include greetings, commentary, or additional messaging.
+- Do **not** respond to casual greetings or small talk. If the input lacks a clear prompt goal, respond with:
+  > *"I'm Promptify. I only generate high-quality prompts. Please provide a clear goal or task to proceed."*
+- Focus exclusively on delivering a powerful, actionable prompt.
+- Avoid vague or generic phrasing — every word must serve a purpose.
 
-Act according to the selected tone: **${style}**.
+Always operate as a top-tier professional in prompt engineering.
 `.trim();
 
     const response = await ai.models.generateContent({

--- a/src/components/TypewriterMarkdown.tsx
+++ b/src/components/TypewriterMarkdown.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import 'highlight.js/styles/github.css';
+import { useEffect, useState } from 'react';
+import Markdown from 'react-markdown';
+import rehypeHighlight from 'rehype-highlight';
+
+type Props = {
+  text: string;
+  speed?: number;
+};
+
+export const TypewriterMarkdown = ({ text, speed = 10 }: Props) => {
+  const [displayedText, setDisplayedText] = useState('');
+
+  useEffect(() => {
+    let i = 0;
+    const interval = setInterval(() => {
+      setDisplayedText((prev) => prev + text.charAt(i));
+      i++;
+      if (i >= text.length) clearInterval(interval);
+    }, speed);
+
+    return () => clearInterval(interval);
+  }, [text, speed]);
+
+  return (
+    <div className='prose prose-sm max-w-none text-sm leading-relaxed whitespace-pre-wrap'>
+      <Markdown rehypePlugins={[rehypeHighlight]}>{displayedText}</Markdown>
+    </div>
+  );
+};

--- a/src/components/tools/prompt-generator.tsx
+++ b/src/components/tools/prompt-generator.tsx
@@ -1,10 +1,30 @@
 'use client';
 
-import { useState } from 'react';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
+import removeMarkdown from 'remove-markdown';
 
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -13,9 +33,18 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { Bot, Trash2 } from 'lucide-react';
+import { TypewriterMarkdown } from '../TypewriterMarkdown';
 
 const styles = ['Funny', 'Formal', 'Creative', 'Professional'] as const;
 type PromptStyle = (typeof styles)[number];
+
+type PromptHistoryItem = {
+  prompt: string;
+  response: string;
+  style: PromptStyle;
+  timestamp: string;
+};
 
 export default function GeneratePrompt() {
   const [prompt, setPrompt] = useState('');
@@ -24,6 +53,18 @@ export default function GeneratePrompt() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [copied, setCopied] = useState(false);
+  const [history, setHistory] = useState<PromptHistoryItem[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('prompt-history');
+    if (stored) setHistory(JSON.parse(stored));
+  }, []);
+
+  const saveToHistory = (item: PromptHistoryItem) => {
+    const updatedHistory = [item, ...history].slice(0, 10);
+    setHistory(updatedHistory);
+    localStorage.setItem('prompt-history', JSON.stringify(updatedHistory));
+  };
 
   const handleSubmit = async () => {
     setLoading(true);
@@ -41,6 +82,13 @@ export default function GeneratePrompt() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Something went wrong');
       setResponse(data.responses);
+
+      saveToHistory({
+        prompt,
+        response: data.responses,
+        style,
+        timestamp: new Date().toISOString(),
+      });
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : 'Something went wrong';
       setError(errorMsg);
@@ -51,67 +99,194 @@ export default function GeneratePrompt() {
 
   const handleCopy = async () => {
     if (!response) return;
-    await navigator.clipboard.writeText(response);
+
+    const plainText = removeMarkdown(response);
+    await navigator.clipboard.writeText(plainText);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };
 
+  const deleteItem = (timestamp: string) => {
+    const updated = history.filter((item) => item.timestamp !== timestamp);
+    setHistory(updated);
+    localStorage.setItem('prompt-history', JSON.stringify(updated));
+  };
+
+  const clearHistory = () => {
+    setHistory([]);
+    localStorage.removeItem('prompt-history');
+  };
+
   return (
-    <main className='mx-auto max-w-3xl space-y-6 p-6'>
-      <div className='space-y-2'>
-        <label className='font-semibold'>Prompt Style</label>
-        <Select value={style} onValueChange={(val: PromptStyle) => setStyle(val)}>
-          <SelectTrigger className='w-full'>
-            <SelectValue placeholder='Select a style' />
-          </SelectTrigger>
-          <SelectContent>
-            {styles.map((s) => (
-              <SelectItem key={s} value={s}>
-                {s}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+    <div className='space-y-6'>
+      <div className='grid gap-6 md:grid-cols-2'>
+        {/* Prompt Generator */}
+        <Card className='modern-card'>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <Bot className='h-5 w-5' />
+              Prompt Generator
+            </CardTitle>
+            <CardDescription>
+              Generate creative, funny, formal, or professional AI prompts instantly!
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='space-y-2'>
+              <Label>Prompt Style</Label>
+              <Select value={style} onValueChange={(val: PromptStyle) => setStyle(val)}>
+                <SelectTrigger className='w-full'>
+                  <SelectValue placeholder='Select a style' />
+                </SelectTrigger>
+                <SelectContent>
+                  {styles.map((s) => (
+                    <SelectItem key={s} value={s}>
+                      {s}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
 
-      <Textarea
-        value={prompt}
-        onChange={(e) => setPrompt(e.target.value)}
-        placeholder='Describe what you want...'
-        rows={6}
-        className='min-h-24 resize-none'
-      />
+            <div className='space-y-2'>
+              <Label>Your Prompt</Label>
+              <Textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                placeholder='Describe what you want...'
+                rows={6}
+                className='min-h-25 resize-none'
+              />
+            </div>
 
-      <Button onClick={handleSubmit} disabled={loading || !prompt.trim()}>
-        {loading ? 'Generating...' : 'Generate'}
-      </Button>
+            {error && <p className='text-sm text-red-600'>Error: {error}</p>}
 
-      {error && <p className='text-red-600'>Error: {error}</p>}
-      {response && (
-        <div className='relative mt-6'>
-          <div className='absolute top-0 right-0'>
-            <Button onClick={handleCopy} variant='secondary' size='sm' className='text-sm'>
-              {copied ? 'Copied!' : 'Copy'}
+            <Button onClick={handleSubmit} disabled={loading || !prompt.trim()}>
+              {loading ? 'Generating...' : 'Generate'}
             </Button>
-          </div>
+          </CardContent>
+        </Card>
+        <Card className='modern-card w-full'>
+          <CardHeader className='flex flex-row items-center justify-between'>
+            <CardTitle>Generated Prompt</CardTitle>
+            {response && (
+              <Button onClick={handleCopy} variant='secondary' size='sm'>
+                {copied ? 'Copied!' : 'Copy'}
+              </Button>
+            )}
+          </CardHeader>
+          <CardContent>
+            {loading && <p className='text-muted-foreground text-sm'>Generating prompt...</p>}
 
-          <div className='bg-foreground-muted prose prose-blue max-w-none overflow-auto rounded border p-4 break-words'>
-            <Markdown
-              rehypePlugins={[rehypeHighlight]}
-              components={{
-                strong: ({ children }) => <strong className='font-semibold'>{children}</strong>,
-                ul: ({ children }) => <ul className='list-disc pl-6'>{children}</ul>,
-                ol: ({ children }) => <ol className='list-decimal pl-6'>{children}</ol>,
-                li: ({ children }) => <li className='mb-1'>{children}</li>,
-                p: ({ children }) => <p className='mb-3'>{children}</p>,
-                h2: ({ children }) => <h2 className='mt-4 text-xl font-bold'>{children}</h2>,
-              }}
-            >
-              {response}
-            </Markdown>
-          </div>
-        </div>
-      )}
-    </main>
+            {!loading && !response && !error && (
+              <p className='text-muted-foreground text-sm'>
+                Your generated prompt will appear here.
+              </p>
+            )}
+
+            {!loading && error && <p className='text-sm text-red-600'>Error: {error}</p>}
+
+            {!loading && response && (
+              <div className='w-full p-4'>
+                <div className='prose dark:prose-invert max-w-none break-words whitespace-pre-wrap'>
+                  <TypewriterMarkdown text={response} />
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+      <Card>
+        <CardHeader className='flex flex-row items-center justify-between'>
+          <CardTitle>Prompt History</CardTitle>
+          {history.length > 0 && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant='destructive' size='sm'>
+                  <Trash2 className='mr-2 h-4 w-4' />
+                  Clear All
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Clear all history?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently delete all prompts and responses from your history. Are
+                    you sure?
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={clearHistory}
+                    className='bg-destructive hover:bg-destructive/90 text-white'
+                  >
+                    Yes, delete all
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </CardHeader>
+        <CardContent>
+          {history.length === 0 ? (
+            <p className='text-muted-foreground text-sm'>No prompt history yet.</p>
+          ) : (
+            <Accordion type='multiple' className='w-full'>
+              {history.map((item, idx) => (
+                <AccordionItem key={idx} value={`item-${idx}`}>
+                  <AccordionTrigger className='text-left'>
+                    <div className='flex flex-col gap-1 text-sm'>
+                      <span className='line-clamp-1 font-medium'>{item.prompt}</span>
+                      <span className='text-muted-foreground text-xs'>
+                        {item.style} • {new Date(item.timestamp).toLocaleString()}
+                      </span>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className='space-y-2 pt-2'>
+                    <div>
+                      <p className='mb-1 font-semibold'>Prompt:</p>
+                      <p className='text-muted-foreground'>{item.prompt}</p>
+                    </div>
+                    <div>
+                      <p className='mb-1 font-semibold'>Response:</p>
+                      <div className='prose prose-blue dark:prose-invert max-w-none'>
+                        <Markdown rehypePlugins={[rehypeHighlight]}>{item.response}</Markdown>
+                      </div>
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button variant='ghost' size='sm' className='text-destructive mt-3'>
+                            <Trash2 className='mr-1 h-4 w-4' />
+                            Delete
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>Delete this prompt?</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              This will remove this prompt and its response from history. This
+                              action cannot be undone.
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogAction
+                              onClick={() => deleteItem(item.timestamp)}
+                              className='bg-destructive hover:bg-destructive/90 text-white'
+                            >
+                              Yes, delete
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { ChevronDownIcon } from 'lucide-react';
+import { Accordion as AccordionPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Accordion({ ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot='accordion' {...props} />;
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot='accordion-item'
+      className={cn('border-b last:border-b-0', className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className='flex'>
+      <AccordionPrimitive.Trigger
+        data-slot='accordion-trigger'
+        className={cn(
+          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className='text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot='accordion-content'
+      className='data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm'
+      {...props}
+    >
+      <div className={cn('pt-0 pb-4', className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger };

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { AlertDialog as AlertDialogPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot='alert-dialog' {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot='alert-dialog-trigger' {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot='alert-dialog-portal' {...props} />;
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot='alert-dialog-overlay'
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot='alert-dialog-content'
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='alert-dialog-header'
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='alert-dialog-footer'
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot='alert-dialog-title'
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot='alert-dialog-description'
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />;
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -11,12 +11,21 @@ import {
   QrCode,
   Ruler,
   Scale,
+  Sparkles,
   Target,
   TimerReset,
   TrendingUp,
 } from 'lucide-react';
 
 export const tools = [
+  {
+    id: 'prompt-generator',
+    name: 'Prompt Generator',
+    description: 'Generate powerful, tailored AI prompts instantly for various use-cases',
+    icon: Sparkles,
+    category: 'AI Tools',
+    popular: true,
+  },
   {
     id: 'image-tools',
     name: 'Image Tools',


### PR DESCRIPTION
## ✨ Features
- Introduced a new **Prompt Generator** tool that helps users generate high-quality prompts based on selected tone and input.
- Includes options like Funny, Formal, and Creative.

## 🔧 Technical Details
- Added `remove-markdown` package to strip markdown from GPT responses.
- Updated `handleCopy` logic in the response component.

## ✅ How to Test
1. Use the Prompt Generator by typing an idea and selecting a tone.
2. Click "Generate" and then "Copy".
3. Verify that only clean text (no markdown syntax) is copied.

## 🔗 Closes
- Closes #19 
